### PR TITLE
#159057284 - Api post new entries

### DIFF
--- a/endpoints/contents.py
+++ b/endpoints/contents.py
@@ -27,3 +27,13 @@ class UserEntry(Resource):
     def get(self):
         """Handle get request of url /entries"""
         return content_data
+
+    @entries_namespace.expect(entries_model)
+    def post(self):
+        """Handle post request of url/entries"""
+        post = request.get_json()
+        date = post["Date"]
+        entry = post["Content"]
+        user_entry = Content(date, entry)
+        user_entry.create()
+        return {"status": "Entry successfully created"}, 201

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -24,3 +24,9 @@ class EntryTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         response = self.client.get('api/v1/user/entries')
         self.assertEqual(response.status_code, 200)
+
+    def test_400_post_a_request(self):
+        """Test bad request on post method"""
+        empty = self.client.post(
+            'api/v1/user/entries', data={}, content_type="application/json")
+        self.assertEqual(empty.status_code, 400)

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -30,3 +30,11 @@ class EntryTestCase(unittest.TestCase):
         empty = self.client.post(
             'api/v1/user/entries', data={}, content_type="application/json")
         self.assertEqual(empty.status_code, 400)
+
+    def test_api_post_entries(self):
+        """Test API url [POST] api/user/entries"""
+        response = self.client.post(
+            'api/v1/user/entries',
+            data=json.dumps(self.data),
+            content_type="application/json")
+        self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
**What does this PR contain?**
This PR contains API for posting new entries to My DIary

**Description of API URL /user/entries**
Returns all entry from the post
`"POST "http://127.0.0.1:5000/api/v1/user/entries""`

**How would this be manually tested**
```
git clone https://github.com/YA7YA-H/DIARY.git
cd Diary
create venv and .env file
pip install -r requirements.txt
python3 run.py
```
open browser and run port `localhost:5000`



**Built with**
`Flask `and` Flask-restplus`

**pivotal tracker ID**
[#159057284](https://www.pivotaltracker.com/story/show/159057284)

screenshot
![15 16-28-53](https://user-images.githubusercontent.com/40847561/42734418-4edc2730-884c-11e8-8538-f531d13cc502.png)



