### PR TITLE
#159057316-Api endpoint for deleting an entry

### DIFF
--- a/endpoints/contents.py
+++ b/endpoints/contents.py
@@ -73,3 +73,13 @@ class UpdateEntry(Resource):
             update_entries[0]["Content"] = post_data["Content"]
 
             return {"status": " Entry content successfully created"}, 201
+
+    def delete(self, contentID):
+        del_item = [
+            del_item for del_item in content_data
+            if del_item["ContentID"] == contentID
+        ]
+        if len(del_item) == 0:
+            return {"Message": "Sorry, No such id is found to be deleted"}, 404
+        del content_data[contentID]
+        return {"status": "Entry successfully deleted"}, 201

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -96,7 +96,7 @@ class EntryTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_delete_an_entry(self):
-        """Test API resource [PUT] endpoint url /user/api"""
+        """Test API resource [DELETE] endpoint url api/user/entries/<id>"""
         response = self.client.post(
             'api/v1/user/entries',
             data=json.dumps(self.data),
@@ -104,3 +104,8 @@ class EntryTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         response = self.client.delete('api/v1/user/entries/1')
         self.assertEqual(response.status_code, 201)
+
+    def test_del_status_400_invalid_id(self):
+        """Test API resource [DELETE] endpoint url api/user/entries/<id>"""
+        response = self.client.delete('api/v1/user/2')
+        self.assertEqual(response.status_code, 404)

--- a/test/test_content.py
+++ b/test/test_content.py
@@ -94,3 +94,13 @@ class EntryTestCase(unittest.TestCase):
         response = self.client.put(
             'api/v1/user/entries/0', data={}, content_type="application/json")
         self.assertEqual(response.status_code, 400)
+
+    def test_delete_an_entry(self):
+        """Test API resource [PUT] endpoint url /user/api"""
+        response = self.client.post(
+            'api/v1/user/entries',
+            data=json.dumps(self.data),
+            content_type="application/json")
+        self.assertEqual(response.status_code, 201)
+        response = self.client.delete('api/v1/user/entries/1')
+        self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
**What does this PR contain?**
This PR contains API for deleting a single entry from My DIary with an ID

**Description of API URL /user/entries**
Update an entry using ID
`"DELETE "http://127.0.0.1:5000/api/v1/user/entries/1""`

**How would this be manually tested**
```
git clone https://github.com/YA7YA-H/DIARY.git
cd Diary
create venv and .env file
pip install -r requirements.txt
python3 run.py
```
open browser and run port `localhost:5000`



**Built with**
`Flask `  and  ` Flask-restplus`

**pivotal tracker ID:**
[#159057316](https://www.pivotaltracker.com/story/show/159057316)
 
**screenshot**
![del](https://user-images.githubusercontent.com/40847561/42759464-c2203678-890f-11e8-85be-8d8e3885fcbe.png)
![del2](https://user-images.githubusercontent.com/40847561/42759472-c8da0930-890f-11e8-80a4-446bcdfbc755.png)
